### PR TITLE
Xử lí sự kiện hiển thị bình luận và thêm bình luận

### DIFF
--- a/src/main/java/vn/edu/hcmuaf/fit/projectwebck/controller/Home/Detail/addComment.java
+++ b/src/main/java/vn/edu/hcmuaf/fit/projectwebck/controller/Home/Detail/addComment.java
@@ -1,0 +1,50 @@
+package vn.edu.hcmuaf.fit.projectwebck.controller.Home.Detail;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.annotation.*;
+import vn.edu.hcmuaf.fit.projectwebck.dao.model.Comment;
+import vn.edu.hcmuaf.fit.projectwebck.services.CommentServices;
+
+import java.io.IOException;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@WebServlet(name = "addComment", value = "/addComment")
+public class addComment extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String productId = request.getParameter("productId");
+        int userId = Integer.parseInt(request.getParameter("userId"));
+        String userName = request.getParameter("userName");
+        String content = request.getParameter("content");
+
+        // Tạo comment object
+        Comment comment = new Comment();
+        comment.setProductId(productId);
+        comment.setUserId(userId);
+        comment.setUserName(userName);
+        comment.setContent(content);
+        comment.setCreatedAt(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+
+        // Thêm bình luận
+        CommentServices commentService = new CommentServices();
+        commentService.insertComment(comment);
+        // /Lấy lại danh sách bình luận mới
+        List<Comment> commentList = commentService.getCommentsByProductId(productId);
+        request.setAttribute("commentList", commentList);
+
+        // Forward lại về trang chi tiết (giả sử là Detail.jsp)
+        request.getRequestDispatcher("/jsp/Detail.jsp").forward(request, response);
+    }
+
+}

--- a/src/main/java/vn/edu/hcmuaf/fit/projectwebck/controller/Home/Detail/showDetail.java
+++ b/src/main/java/vn/edu/hcmuaf/fit/projectwebck/controller/Home/Detail/showDetail.java
@@ -2,7 +2,9 @@ package vn.edu.hcmuaf.fit.projectwebck.controller.Home.Detail;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import jakarta.servlet.annotation.*;
+import vn.edu.hcmuaf.fit.projectwebck.dao.model.Comment;
 import vn.edu.hcmuaf.fit.projectwebck.dao.model.Product;
+import vn.edu.hcmuaf.fit.projectwebck.services.CommentServices;
 import vn.edu.hcmuaf.fit.projectwebck.services.ProductServices;
 
 import java.io.IOException;
@@ -19,6 +21,10 @@ public class showDetail extends  HttpServlet{
         Product detail = productService.getDetail(id);
         request.setAttribute("p",detail);
         System.out.println("product in detail" + detail);
+        CommentServices commentService= new CommentServices();
+        List<Comment> commentList= commentService.getCommentsByProductId(id);
+        request.setAttribute("commentList",commentList);
+
         // Lấy mô tả sản phẩm
         List<String> descriptions = productService.getDescription(id);
         List<String> sentences = new ArrayList<>();

--- a/src/main/java/vn/edu/hcmuaf/fit/projectwebck/dao/CommentDao.java
+++ b/src/main/java/vn/edu/hcmuaf/fit/projectwebck/dao/CommentDao.java
@@ -1,0 +1,29 @@
+package vn.edu.hcmuaf.fit.projectwebck.dao;
+
+import org.jdbi.v3.core.Jdbi;
+import vn.edu.hcmuaf.fit.projectwebck.dao.db.JDBIConect;
+import vn.edu.hcmuaf.fit.projectwebck.dao.model.Comment;
+
+import java.util.List;
+
+public class CommentDao {
+    Jdbi jdbi = JDBIConect.get();
+    // Lấy tất cả bình luận của một sản phẩm
+    public  List<Comment> getCommentsByProductId(String productId) {
+        return jdbi.withHandle(handle -> handle.createQuery("SELECT * FROM comments WHERE productId = :productId ORDER BY createdAt DESC")
+                .bind("productId", productId)
+                .mapToBean(Comment.class)
+                .list());
+    }
+
+
+    // Thêm bình luận mới
+    public  void insertComment(Comment comment) {
+        jdbi.useHandle(handle -> handle.createUpdate("INSERT INTO comments(productId, userId, userName, content, createdAt) VALUES(:productId, :userId, :userName, :content, NOW())")
+                .bindBean(comment)
+                .execute());
+    }
+
+
+
+}

--- a/src/main/java/vn/edu/hcmuaf/fit/projectwebck/dao/model/Comment.java
+++ b/src/main/java/vn/edu/hcmuaf/fit/projectwebck/dao/model/Comment.java
@@ -1,0 +1,72 @@
+package vn.edu.hcmuaf.fit.projectwebck.dao.model;
+
+import java.sql.Timestamp;
+
+public class Comment {
+    private int id;
+    private String productId;
+    private int userId;
+    private String userName;
+    private String content;
+    private String createdAt;
+
+    public Comment(int id, String productId, int userId, String userName, String content, String createdAt) {
+        this.id = id;
+        this.productId = productId;
+        this.userId = userId;
+        this.userName = userName;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+
+    public Comment() {
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/vn/edu/hcmuaf/fit/projectwebck/services/CommentServices.java
+++ b/src/main/java/vn/edu/hcmuaf/fit/projectwebck/services/CommentServices.java
@@ -1,0 +1,24 @@
+package vn.edu.hcmuaf.fit.projectwebck.services;
+
+import org.jdbi.v3.core.Jdbi;
+import vn.edu.hcmuaf.fit.projectwebck.dao.CommentDao;
+import vn.edu.hcmuaf.fit.projectwebck.dao.db.JDBIConect;
+import vn.edu.hcmuaf.fit.projectwebck.dao.model.Comment;
+
+import java.util.List;
+
+public class CommentServices {
+    CommentDao commentDao = new CommentDao();
+    // Lấy tất cả bình luận của một sản phẩm
+    public  List<Comment> getCommentsByProductId(String productId) {
+        return commentDao.getCommentsByProductId(productId);
+    }
+
+
+    // Thêm bình luận mới
+    public void insertComment(Comment comment) {
+        commentDao.insertComment(comment);
+    }
+
+
+}

--- a/src/main/webapp/jsp/Detail.jsp
+++ b/src/main/webapp/jsp/Detail.jsp
@@ -327,33 +327,31 @@
             <h2>Bình luận sản phẩm</h2>
 
             <div class="comment-form">
-                <textarea placeholder="Viết bình luận của bạn..."></textarea>
-                <br>
-                <button>Gửi bình luận</button>
+                <form method="post" action="addComment">
+                    <textarea name="content" placeholder="Viết bình luận của bạn..." required></textarea>
+                    <input type="hidden" name="productId" value="${p.id}" />
+                    <input type="hidden" name="userId" value="${sessionScope.user.id}" />
+                    <input type="hidden" name="userName" value="${sessionScope.user.username}" />
+                    <br>
+                    <button type="submit" name="action" value="add">Gửi bình luận</button>
+                </form>
             </div>
 
             <div class="comment-list">
-                <div class="comment">
-                    <img src="https://i.pravatar.cc/40" alt="User">
-                    <div class="comment-body">
-                        <div class="name">Nguyễn Văn A</div>
-                        <div class="date">03/05/2025</div>
-                        <div class="text">Sản phẩm rất tốt, giao hàng nhanh!</div>
-                        <div class="correction"><i class="fa-solid fa-trash"></i><i
-                                class="fa-solid fa-pen-to-square"></i></div>
+                <c:forEach var="comment" items="${commentList}">
+                    <div class="comment">
+                        <img src="<%= request.getContextPath() %>/Img/avatarUser.jpg" alt="">
+                        <div class="comment-body">
+                            <div class="name">${comment.userName}</div>
+                            <div class="date">${comment.createdAt}</div>
+                            <div class="text">${comment.content}</div>
+                            <c:if test="${sessionScope.user.id == comment.userId}">
+                                <div class="correction"><i class="fa-solid fa-trash"></i><i
+                                        class="fa-solid fa-pen-to-square"></i></div>
+                            </c:if>
+                        </div>
                     </div>
-                </div>
-
-                <div class="comment">
-                    <img src="https://i.pravatar.cc/41" alt="User">
-                    <div class="comment-body">
-                        <div class="name">Trần Thị B</div>
-                        <div class="date">02/05/2025</div>
-                        <div class="text">Đóng gói kỹ, đúng mô tả. Sẽ ủng hộ tiếp!</div>
-                        <div class="correction"><i class="fa-solid fa-trash"></i><i
-                                class="fa-solid fa-pen-to-square"></i></div>
-                    </div>
-                </div>
+                </c:forEach>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Mô tả vấn đề:

Khi người dùng truy cập vào trang sản phẩm hoặc bài viết, cần hiển thị các bình luận đã có trước đó. Mỗi bình luận sẽ bao gồm tên người dùng, nội dung bình luận, và thời gian bình luận.

Người dùng có thể thêm bình luận mới vào bài viết hoặc sản phẩm, với yêu cầu nhập nội dung bình luận

Mục tiêu:

Hiển thị danh sách các bình luận đã có trước đó.

Cung cấp ô nhập liệu cho người dùng để thêm bình luận mới.

Khi người dùng gửi bình luận mới, hiển thị ngay lập tức trong danh sách bình luận mà không cần tải lại trang.

Cập nhật cơ sở dữ liệu với bình luận mới.

Các bước thực hiện:

Hiển thị các bình luận đã có:

Lấy dữ liệu bình luận từ cơ sở dữ liệu và hiển thị danh sách bình luận trên giao diện người dùng.

Mỗi bình luận bao gồm tên người dùng, nội dung bình luận, và thời gian đăng.

Thêm bình luận mới:

Cung cấp ô nhập liệu cho người dùng để nhập tên và nội dung bình luận.

Khi người dùng nhấn nút "Gửi bình luận", gửi yêu cầu POST tới máy chủ để thêm bình luận vào cơ sở dữ liệu.