### PR TITLE
Xử lí sự kiện xác nhận đã nhận được hàng và hủy đơn ở phía trang khách hàng

### DIFF
--- a/src/main/java/vn/edu/hcmuaf/fit/projectwebck/controller/Admin/Order/cancelOrder.java
+++ b/src/main/java/vn/edu/hcmuaf/fit/projectwebck/controller/Admin/Order/cancelOrder.java
@@ -1,0 +1,30 @@
+package vn.edu.hcmuaf.fit.projectwebck.controller.Admin.Order;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.annotation.*;
+import vn.edu.hcmuaf.fit.projectwebck.services.OrderServices;
+
+import java.io.IOException;
+
+@WebServlet(name = "cancelOrder", value = "/cancelOrder")
+public class cancelOrder extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        int orderId = Integer.parseInt(request.getParameter("orderId"));
+        int status = Integer.parseInt(request.getParameter("status"));
+        String option = request.getParameter("option");
+        String uIdParam = request.getParameter("uId");
+        OrderServices service = new OrderServices();
+        service.updateOrderStatus(orderId, status);
+        request.setAttribute("option", option);
+        request.setAttribute("uIdParam", uIdParam);
+        RequestDispatcher dispatcher = request.getRequestDispatcher("/showCustomer");
+        dispatcher.forward(request, response);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    }
+}

--- a/src/main/java/vn/edu/hcmuaf/fit/projectwebck/controller/Admin/Order/confirmOrder.java
+++ b/src/main/java/vn/edu/hcmuaf/fit/projectwebck/controller/Admin/Order/confirmOrder.java
@@ -1,0 +1,34 @@
+package vn.edu.hcmuaf.fit.projectwebck.controller.Admin.Order;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.annotation.*;
+import vn.edu.hcmuaf.fit.projectwebck.dao.model.EmailService;
+import vn.edu.hcmuaf.fit.projectwebck.dao.model.Order;
+import vn.edu.hcmuaf.fit.projectwebck.dao.model.User;
+import vn.edu.hcmuaf.fit.projectwebck.services.OrderServices;
+import vn.edu.hcmuaf.fit.projectwebck.services.UserServices;
+
+import java.io.IOException;
+
+@WebServlet(name = "confirmOrder", value = "/confirmOrder")
+public class confirmOrder extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        int orderId = Integer.parseInt(request.getParameter("orderId"));
+        int status = Integer.parseInt(request.getParameter("status"));
+        String option = request.getParameter("option");
+        String uIdParam = request.getParameter("uId");
+        OrderServices service = new OrderServices();
+        service.updateOrderStatus(orderId, status);
+        request.setAttribute("option", option);
+        request.setAttribute("uIdParam", uIdParam);
+        RequestDispatcher dispatcher = request.getRequestDispatcher("/showCustomer");
+        dispatcher.forward(request, response);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    }
+}

--- a/src/main/webapp/Customer.css
+++ b/src/main/webapp/Customer.css
@@ -295,12 +295,14 @@ td .OrderAddress {
     cursor: pointer;
 
 }
-td .OrderAddress:hover{
+
+td .OrderAddress:hover {
     white-space: normal;
     overflow: visible;
     text-overflow: unset;
     z-index: 1;
 }
+
 .Detail:hover i,
 .Detail:hover span {
     cursor: pointer;
@@ -321,7 +323,11 @@ td .Detail .fa-solid {
     color: white;
     border-radius: 10px;
     border: none;
+    cursor: pointer;
+}
 
+.OderWindow button:hover {
+    background-color: #4CAF50;
 }
 
 .status-0 {

--- a/src/main/webapp/Customer.js
+++ b/src/main/webapp/Customer.js
@@ -87,7 +87,7 @@ function editAccountInf(userId){
             .catch(error => console.error("Lỗi:", error));
     }
 }
-async function  viewOrder(orderId,address,dateOfBooking) {
+async function  viewOrder(orderId,address,dateOfBooking,status,uId) {
     const response = await fetch(`/web/detailOrder?orderId=${orderId}`);
     const orderDetails = await response.json();
     const viewOrder = document.getElementById("OderWindow");
@@ -123,6 +123,18 @@ async function  viewOrder(orderId,address,dateOfBooking) {
     viewOrder.querySelector(".total").innerText = totalAmount+'VND';
     viewOrder.querySelector(".delivery").innerText = address;
     viewOrder.querySelector(".deliveryDate").innerText = dateOfBooking;
+    const confirm= viewOrder.querySelector(".confirm");
+    confirm.innerHTML="";
+    confirm.innerHTML = `<a href="confirmOrder?orderId=${orderId}&status=4&option=option2&uId=${uId}">Đã nhận hàng</a>`;
+    const cancelOrder=viewOrder.querySelector(".cancelOrder");
+    cancelOrder.innerHTML="";
+    cancelOrder.innerHTML = `<a href="cancelOrder?orderId=${orderId}&status=5&option=option2&uId=${uId}">Hủy đơn</a>`;
+    if (status > 3 && status < 6) {
+        confirm.style.display = "none";
+    }
+    if (status > 2 && status < 6) {
+        cancelOrder.style.display = "none";
+    }
     //
     viewOrder.style.display = "block";
 

--- a/src/main/webapp/Customer.jsp
+++ b/src/main/webapp/Customer.jsp
@@ -168,7 +168,7 @@
                                 <td><span class="Order_Money">${order.money}đ</span></td>
                                 <td>
                                     <div class="Detail"
-                                         onclick="viewOrder('${order.id}','${order.address}','${order.dateOfBooking}')">
+                                         onclick="viewOrder('${order.id}','${order.address}','${order.dateOfBooking}','${order.status}','${sessionScope.user.id}')">
                                         <i class="fa-regular fa-eye"></i><span>Xem</span>
                                     </div>
                                 </td>
@@ -192,7 +192,8 @@
                             <div class="DeliveryAddress">
                                 <span class="text">Ngày đặt:<span class="deliveryDate"> </span></span>
                             </div>
-                            <button>Đã nhận hàng</button>
+                            <button class="confirm" ></button>
+                            <button class="cancelOrder"></button>
                         </div>
                     </table>
                 </div>
@@ -305,20 +306,6 @@
                         </div>
                     </div>
                 </div>
-            </div>
-        </div>
-    </div>
-</div>
-
-<div class="modal fade" id="setOriginAddressModal" tabindex="-1" aria-labelledby="setOriginAddressModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="setOriginAddressModalLabel">Thông báo</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body" id="setOriginAddressModalBody">
-                <!-- message inserted dynamically -->
             </div>
         </div>
     </div>


### PR DESCRIPTION
📌 Mô tả:
Người dùng (khách hàng) cần có khả năng xác nhận đã nhận hàng hoặc hủy đơn hàng thông qua giao diện đặt hàng của mình. Khi người dùng nhấn nút tương ứng, hệ thống cần cập nhật trạng thái đơn hàng phù hợp và hiển thị lại thông tin đơn hàng nếu cần.
Nhấn "Đã nhận hàng" → trạng thái cập nhật, nút ẩn đi.
Nhấn "Hủy đơn" → trạng thái cập nhật, nút ẩn đi.
Đơn hàng đã hoàn tất hoặc đã hủy thì không còn hiện các nút nữa.

🎯 Mục tiêu:
Khi khách hàng nhấn “Đã nhận hàng”, trạng thái đơn hàng sẽ được cập nhật thành “Hoàn tất” (status = 4) trong hệ thống.

Khi khách hàng nhấn “Hủy đơn”, trạng thái đơn hàng sẽ được cập nhật thành “Đã hủy” (status = 5) trong hệ thống.

Ẩn các nút “Đã nhận hàng” và “Hủy đơn” nếu đơn hàng đã được xác nhận, đang xử lý hoặc hoàn tất

